### PR TITLE
Prevent slab from animating during print simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# personal
+# Personal Projects
+
+## Parametric Tiny House Fabricator
+
+This repository now includes an experimental web studio for automatically generating unique, fabrication-aware tiny house concepts. Open `tiny-house-studio.html` in a modern browser to:
+
+- Configure site, sustainability, and systems criteria.
+- Synthesize dozens of distinct layouts with immersive 3D visualization powered by three.js.
+- Inspect tabbed reports covering spatial programming, bill of materials, scheduling, and financial projections.
+- Evaluate climate risk using live Open-Meteo climate datasets tied to the project location.
+- Run a simulated 3D printing sequence and export a captured WebM video.
+
+All computations run client-side; no build step is required.

--- a/scripts/tiny-house.js
+++ b/scripts/tiny-house.js
@@ -1,0 +1,762 @@
+import * as THREE from "https://unpkg.com/three@0.155.0/build/three.module.js";
+import { OrbitControls } from "https://unpkg.com/three@0.155.0/examples/jsm/controls/OrbitControls.js";
+import { Sky } from "https://unpkg.com/three@0.155.0/examples/jsm/objects/Sky.js";
+
+const ui = {
+    generate: document.getElementById("generate"),
+    variantCount: document.getElementById("variantCount"),
+    variantLabel: document.getElementById("variantCountLabel"),
+    designList: document.getElementById("designList"),
+    activeDesignTitle: document.getElementById("activeDesignTitle"),
+    layoutSummary: document.getElementById("layoutSummary"),
+    highlightPills: document.getElementById("highlightPills"),
+    marketInsights: document.getElementById("marketInsights"),
+    materialsTable: document.querySelector("#materialsTable tbody"),
+    timelineInsights: document.getElementById("timelineInsights"),
+    financialInsights: document.getElementById("financialInsights"),
+    systemsInsights: document.getElementById("systemsInsights"),
+    envelopeInsights: document.getElementById("envelopeInsights"),
+    climateRisk: document.getElementById("climateRisk"),
+    climateStrategies: document.getElementById("climateStrategies"),
+    metricArea: document.getElementById("metricArea"),
+    metricCarbon: document.getElementById("metricCarbon"),
+    metricEnergy: document.getElementById("metricEnergy"),
+    simulatePrint: document.getElementById("simulatePrint"),
+    recordVideo: document.getElementById("recordVideo"),
+    simulationStatus: document.getElementById("simulationStatus"),
+    videoPreview: document.getElementById("videoPreview"),
+    simulationVideo: document.getElementById("simulationVideo"),
+    downloadLink: document.getElementById("downloadLink"),
+};
+
+const lensToggles = {
+    roof: document.getElementById("toggleRoof"),
+    walls: document.getElementById("toggleWalls"),
+    structure: document.getElementById("toggleStructure"),
+    systems: document.getElementById("toggleSystems"),
+};
+
+ui.variantCount.addEventListener("input", () => {
+    ui.variantLabel.textContent = `${ui.variantCount.value} layouts queued`;
+});
+
+document.querySelectorAll("[data-collapsible]").forEach((group) => {
+    group.querySelector("header").addEventListener("click", () => {
+        group.classList.toggle("collapsed");
+    });
+});
+
+document.querySelectorAll(".viewport-tabs button").forEach((btn) => {
+    btn.addEventListener("click", () => {
+        document.querySelectorAll(".viewport-tabs button").forEach((b) => b.classList.remove("active"));
+        btn.classList.add("active");
+        const tab = btn.dataset.tab;
+        document.querySelectorAll("[data-tab-panel]").forEach((panel) => {
+            panel.classList.toggle("active", panel.dataset.tabPanel === tab);
+        });
+    });
+});
+
+const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById("three-canvas"), antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+camera.position.set(8, 6, 10);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+controls.target.set(0, 1.2, 0);
+
+const ambient = new THREE.HemisphereLight(0xe0f2fe, 0x0f172a, 0.65);
+scene.add(ambient);
+
+const sun = new THREE.DirectionalLight(0xffffff, 1.05);
+sun.position.set(10, 15, 8);
+sun.castShadow = true;
+scene.add(sun);
+
+const sky = new Sky();
+sky.scale.setScalar(450000);
+scene.add(sky);
+const skyUniforms = sky.material.uniforms;
+skyUniforms["turbidity"].value = 8;
+skyUniforms["rayleigh"].value = 0.3;
+skyUniforms["mieCoefficient"].value = 0.005;
+skyUniforms["mieDirectionalG"].value = 0.7;
+
+const sunSphere = new THREE.Vector3();
+function updateSun(elevation = 50, azimuth = 120) {
+    const phi = THREE.MathUtils.degToRad(90 - elevation);
+    const theta = THREE.MathUtils.degToRad(azimuth);
+    sunSphere.setFromSphericalCoords(1, phi, theta);
+    sun.position.copy(sunSphere.clone().multiplyScalar(50));
+    sun.target.position.set(0, 0, 0);
+}
+updateSun();
+
+const ground = new THREE.Mesh(
+    new THREE.PlaneGeometry(80, 80),
+    new THREE.MeshStandardMaterial({ color: 0x1e293b })
+);
+ground.rotation.x = -Math.PI / 2;
+ground.receiveShadow = true;
+scene.add(ground);
+
+const lensGroups = {
+    roof: new THREE.Group(),
+    walls: new THREE.Group(),
+    structure: new THREE.Group(),
+    systems: new THREE.Group(),
+};
+
+Object.values(lensGroups).forEach((group) => scene.add(group));
+
+const environmentGroup = new THREE.Group();
+scene.add(environmentGroup);
+
+function clearGroups() {
+    Object.values(lensGroups).forEach((group) => {
+        while (group.children.length) {
+            group.remove(group.children[0]);
+        }
+    });
+}
+
+function applyLensVisibility() {
+    lensGroups.roof.visible = lensToggles.roof.checked;
+    lensGroups.walls.children.forEach((mesh) => {
+        mesh.material.opacity = lensToggles.walls.checked ? 0.95 : 0.25;
+        mesh.material.transparent = true;
+        mesh.material.needsUpdate = true;
+    });
+    lensGroups.structure.visible = lensToggles.structure.checked;
+    lensGroups.systems.visible = lensToggles.systems.checked;
+}
+
+Object.values(lensToggles).forEach((toggle) => toggle.addEventListener("change", applyLensVisibility));
+
+const state = {
+    designs: [],
+    activeDesign: null,
+    animation: null,
+    mediaRecorder: null,
+    recordedChunks: [],
+    environment: "auto",
+};
+
+const randomChoice = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+function seededRandom(seed) {
+    let t = seed += 0x6d2b79f5;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
+function generateLayout(seed, params) {
+    const rand = () => seededRandom((seed = (seed * 1664525 + 1013904223) >>> 0));
+    const area = params.area;
+    const floors = Number(params.floors);
+    const baseLength = Math.sqrt(area * (rand() * 0.4 + 0.8));
+    const baseWidth = area / baseLength;
+    const roomCount = params.bedrooms + params.bathrooms + 2;
+    const rooms = [];
+    const modules = Math.max(4, Math.round(roomCount * (rand() * 0.4 + 0.9)));
+    const moduleWidth = baseWidth / Math.max(2, Math.round(rand() * 3 + 2));
+    const moduleLength = baseLength / Math.max(2, Math.round(rand() * 3 + 2));
+
+    let x = -baseWidth / 2;
+    let z = -baseLength / 2;
+    for (let i = 0; i < modules; i++) {
+        const width = moduleWidth * (rand() * 0.6 + 0.6);
+        const length = moduleLength * (rand() * 0.6 + 0.6);
+        rooms.push({
+            id: `module-${i}`,
+            width,
+            length,
+            height: 3 * floors,
+            x: x + width / 2,
+            z: z + length / 2,
+            type: assignRoomType(i, params, rand),
+        });
+        x += width;
+        if (x > baseWidth / 2) {
+            x = -baseWidth / 2;
+            z += moduleLength;
+        }
+    }
+
+    const connectors = Array.from({ length: Math.max(1, Math.round(rand() * 2 + floors)) }, (_, idx) => ({
+        id: `core-${idx}`,
+        x: (rand() - 0.5) * baseWidth * 0.6,
+        z: (rand() - 0.5) * baseLength * 0.6,
+        radius: rand() * 0.8 + 0.6,
+        type: rand() > 0.6 ? "atrium" : "service",
+    }));
+
+    const features = {
+        glazingRatio: 0.25 + rand() * 0.35,
+        roofType: randomChoice(["Butterfly", "Mono-Pitch", "Gable", "Green Roof", "Solar Canopy"]),
+        facade: randomChoice(["Engineered Timber", "Basalt Composite", "Upcycled Aluminum", "Ceramic Panels"]),
+        lighting: randomChoice(["Dynamic Circadian", "Smart Dimmable", "Daylight Harvesting"]),
+        shading: randomChoice(["Electrochromic", "Kinetic Louvers", "Retractable Awning"]),
+    };
+
+    return {
+        id: `Design-${Math.random().toString(36).slice(2, 8).toUpperCase()}`,
+        rooms,
+        connectors,
+        floors,
+        footprint: { width: baseWidth, length: baseLength },
+        features,
+        params,
+    };
+}
+
+function assignRoomType(index, params, rand) {
+    const palette = [
+        "Great Room",
+        "Kitchen",
+        "Dining Nook",
+        "Flex Studio",
+        "Workspace",
+        "Library",
+        "Mudroom",
+        "Utility",
+    ];
+    const bedrooms = Array.from({ length: params.bedrooms }, (_, i) => `Bedroom ${i + 1}`);
+    const baths = Array.from({ length: params.bathrooms }, (_, i) => `${i === 0 ? "Primary" : "Guest"} Bath`);
+    const catalog = [...bedrooms, ...baths, ...palette];
+    return catalog[Math.floor(rand() * catalog.length)] || randomChoice(palette);
+}
+
+function buildDesign(design) {
+    clearGroups();
+    const wallMaterial = new THREE.MeshStandardMaterial({ color: 0xe2e8f0, roughness: 0.45, metalness: 0 });
+    const floorMaterial = new THREE.MeshStandardMaterial({ color: 0x1e293b, roughness: 0.8 });
+    const roofMaterial = new THREE.MeshStandardMaterial({ color: 0x0f172a, emissive: 0x020617, roughness: 0.6 });
+    const structureMaterial = new THREE.MeshStandardMaterial({ color: 0x38bdf8, metalness: 0.6, roughness: 0.35 });
+    const systemsMaterial = new THREE.MeshStandardMaterial({ color: 0xf97316, emissive: 0x7c2d12, metalness: 0.1, roughness: 0.2 });
+
+    const floor = new THREE.Mesh(
+        new THREE.BoxGeometry(design.footprint.width + 0.1, 0.2, design.footprint.length + 0.1),
+        floorMaterial
+    );
+    floor.receiveShadow = true;
+    floor.position.y = 0;
+    floor.userData.isSlab = true;
+    floor.userData.originalScaleY = floor.scale.y;
+    floor.userData.baseY = floor.position.y;
+    lensGroups.walls.add(floor);
+
+    design.rooms.forEach((room) => {
+        const wall = new THREE.Mesh(new THREE.BoxGeometry(room.width, room.height, room.length), wallMaterial.clone());
+        wall.position.set(room.x, room.height / 2, room.z);
+        wall.castShadow = true;
+        wall.receiveShadow = true;
+        wall.userData.room = room;
+        wall.userData.originalScaleY = wall.scale.y;
+        lensGroups.walls.add(wall);
+
+        const structure = new THREE.Mesh(new THREE.BoxGeometry(room.width + 0.08, room.height + 0.2, room.length + 0.08), structureMaterial);
+        structure.position.copy(wall.position);
+        structure.material.transparent = true;
+        structure.material.opacity = 0.08;
+        lensGroups.structure.add(structure);
+    });
+
+    const roof = new THREE.Mesh(
+        new THREE.BoxGeometry(design.footprint.width + 0.3, 0.18, design.footprint.length + 0.3),
+        roofMaterial
+    );
+    roof.position.y = design.rooms[0]?.height + 0.15 || 3.2;
+    roof.castShadow = true;
+    lensGroups.roof.add(roof);
+
+    design.connectors.forEach((core) => {
+        const pipe = new THREE.Mesh(new THREE.CylinderGeometry(core.radius * 0.3, core.radius * 0.3, 3.6, 24), systemsMaterial);
+        pipe.position.set(core.x, 1.6, core.z);
+        pipe.material.transparent = true;
+        pipe.material.opacity = 0.6;
+        lensGroups.systems.add(pipe);
+
+        const conduit = new THREE.Mesh(new THREE.TorusGeometry(core.radius, 0.05, 8, 32), systemsMaterial.clone());
+        conduit.rotation.x = Math.PI / 2;
+        conduit.position.set(core.x, 2.2, core.z);
+        lensGroups.systems.add(conduit);
+    });
+
+    applyLensVisibility();
+}
+
+function describeDesign(design, analytics) {
+    ui.activeDesignTitle.textContent = `${design.id} · ${analytics.programProfile}`;
+    ui.layoutSummary.innerHTML = design.rooms
+        .slice(0, 12)
+        .map((room) => `<div class="info-row"><span>${room.type}</span><span>${room.width.toFixed(1)}m × ${room.length.toFixed(1)}m</span></div>`)
+        .join("");
+    ui.highlightPills.innerHTML = analytics.highlights.map((h) => `<span>${h}</span>`).join("");
+    ui.marketInsights.innerHTML = analytics.market.map((m) => `<div class="info-row"><span>${m.label}</span><span>${m.value}</span></div>`).join("");
+    ui.metricArea.textContent = `${Math.round(analytics.areaSqft).toLocaleString()} sqft`;
+    ui.metricCarbon.textContent = `${Math.round(analytics.embodiedCarbon).toLocaleString()} kg CO₂e`;
+    ui.metricEnergy.textContent = `${Math.round(analytics.energyUse).toLocaleString()} kWh/yr`;
+
+    ui.materialsTable.innerHTML = analytics.materials
+        .map((mat) => `<tr><td>${mat.name}</td><td>${mat.quantity}</td><td>${mat.unitCost}</td><td>${mat.total}</td></tr>`)
+        .join("");
+    ui.timelineInsights.innerHTML = analytics.timeline
+        .map((entry) => `<div class="info-row"><span>${entry.label}</span><span>${entry.value}</span></div>`)
+        .join("");
+    ui.financialInsights.innerHTML = analytics.financial
+        .map((entry) => `<div class="info-row"><span>${entry.label}</span><span>${entry.value}</span></div>`)
+        .join("");
+    ui.systemsInsights.innerHTML = analytics.systems
+        .map((entry) => `<div class="info-row"><span>${entry.label}</span><span>${entry.value}</span></div>`)
+        .join("");
+    ui.envelopeInsights.innerHTML = analytics.envelope
+        .map((entry) => `<div class="info-row"><span>${entry.label}</span><span>${entry.value}</span></div>`)
+        .join("");
+    ui.climateRisk.innerHTML = analytics.climateRisks
+        .map(
+            (risk) => `
+            <div class="risk-card">
+                <header><strong>${risk.type}</strong><span class="risk-${risk.level.toLowerCase()}">${risk.level}</span></header>
+                <p>${risk.description}</p>
+            </div>
+        `
+        )
+        .join("");
+    ui.climateStrategies.innerHTML = analytics.climateStrategies
+        .map((entry) => `<div class="info-row"><span>${entry.label}</span><span>${entry.value}</span></div>`)
+        .join("");
+}
+
+function computeAnalytics(design, context) {
+    const floorArea = design.footprint.width * design.footprint.length * design.floors;
+    const areaSqft = floorArea * 10.7639;
+    const wallArea = design.rooms.reduce((sum, room) => sum + (room.width + room.length) * 2 * room.height, 0);
+    const envelopeFactor = { standard: 1, hempcrete: 0.85, recycled: 0.72, "mass-timber": 0.92 }[design.params.envelope] || 1;
+    const carbonIntensity = { standard: 52, hempcrete: 34, recycled: 28, "mass-timber": 40 }[design.params.envelope] || 52;
+    const embodiedCarbon = wallArea * carbonIntensity * envelopeFactor;
+    const energyMultiplier = { hybrid: 0.82, geothermal: 0.65, grid: 1.05, microgrid: 0.78 }[design.params.energySystem] || 1;
+    const climateEnergy = context?.climate?.degreeDays ? 1 + (context.climate.degreeDays - 3000) / 12000 : 1;
+    const energyUse = areaSqft * 14 * energyMultiplier * climateEnergy;
+    const highlights = [
+        `${design.features.roofType} roof`,
+        `${Math.round(design.features.glazingRatio * 100)}% glazing`,
+        `${design.params.energySystem} energy hub`,
+        `${design.params.envelope} envelope`,
+    ];
+
+    const marketValue = estimateMarketValue(areaSqft, context?.location || null);
+    const materialCosts = buildMaterialCosts(design, floorArea, wallArea, envelopeFactor, marketValue.costFactor);
+    const timeline = buildTimeline(design, floorArea, materialCosts.printHours, design.params.fabricator);
+    const financial = buildFinancials(materialCosts, marketValue);
+    const systems = buildSystems(design, energyUse);
+    const envelope = buildEnvelope(design, context?.climate);
+    const climateRisks = assessClimate(context?.climate, context?.location);
+    const climateStrategies = buildClimateStrategies(climateRisks, design);
+
+    return {
+        areaSqft,
+        embodiedCarbon,
+        energyUse,
+        highlights,
+        programProfile: `${design.params.bedrooms}BR/${design.params.bathrooms}BA · ${design.floors}-level`,
+        materials: materialCosts.entries,
+        timeline,
+        financial,
+        systems,
+        envelope,
+        climateRisks,
+        climateStrategies,
+        market: [
+            { label: "Est. Sale Value", value: materialCosts.currencyFormatter.format(marketValue.saleValue) },
+            { label: "Projected ROI", value: `${(marketValue.saleValue / materialCosts.totalCost * 100 - 100).toFixed(1)}%` },
+            { label: "Local Build Pressure", value: marketValue.marketPressure },
+        ],
+    };
+}
+
+function buildMaterialCosts(design, floorArea, wallArea, envelopeFactor, costFactor) {
+    const unitCosts = {
+        foundation: 75 * costFactor,
+        wall: 32 * costFactor * envelopeFactor,
+        roof: 28 * costFactor,
+        glazing: 55 * costFactor,
+        finish: 40 * costFactor,
+        systems: 45 * costFactor,
+    };
+    const foundationVolume = design.footprint.width * design.footprint.length * 0.35;
+    const roofArea = design.footprint.width * design.footprint.length;
+    const glazingArea = wallArea * design.features.glazingRatio;
+    const entriesRaw = [
+        { name: "3D Print Concrete", quantity: `${foundationVolume.toFixed(1)} m³`, total: foundationVolume * unitCosts.foundation },
+        { name: "Envelope Shell", quantity: `${wallArea.toFixed(0)} m²`, total: wallArea * unitCosts.wall },
+        { name: "Roof Assembly", quantity: `${roofArea.toFixed(0)} m²`, total: roofArea * unitCosts.roof },
+        { name: "Glazing Package", quantity: `${glazingArea.toFixed(0)} m²`, total: glazingArea * unitCosts.glazing },
+        { name: "Interior Fit-Out", quantity: `${(floorArea * 0.9).toFixed(0)} m²`, total: floorArea * 0.9 * unitCosts.finish },
+        { name: "Systems Integration", quantity: `${design.connectors.length} cores`, total: design.connectors.length * unitCosts.systems * 80 },
+    ];
+    const totalCost = entriesRaw.reduce((sum, item) => sum + item.total, 0);
+    const currencyFormatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+    const entries = entriesRaw.map((entry) => ({
+        name: entry.name,
+        quantity: entry.quantity,
+        unitCost: currencyFormatter.format(entry.total / Math.max(1, parseFloat(entry.quantity))),
+        total: currencyFormatter.format(entry.total),
+    }));
+    const printHours = (floorArea * 10.7639) / { gantry: 48, arm: 55, swarm: 38 }[design.params.fabricator] * 2;
+    return { entries, totalCost, printHours, currencyFormatter };
+}
+
+function buildTimeline(design, floorArea, printHours, fabricator) {
+    const totalDays = Math.ceil(printHours / 12 + design.floors * 1.5 + 6);
+    return [
+        { label: "Print Duration", value: `${printHours.toFixed(1)} hrs` },
+        { label: "Post-Processing", value: `${(design.floors * 1.5).toFixed(1)} days` },
+        { label: "Systems Fit-Out", value: `${(floorArea * 0.3).toFixed(1)} crew hrs` },
+        { label: "Total Schedule", value: `${totalDays} days (${fabricator})` },
+    ];
+}
+
+function buildFinancials(materialCosts, marketValue) {
+    const formatter = materialCosts.currencyFormatter;
+    return [
+        { label: "Total Material Cost", value: formatter.format(materialCosts.totalCost) },
+        { label: "Soft Costs + Labor", value: formatter.format(materialCosts.totalCost * 0.35) },
+        { label: "Lifecycle Maintenance (10yr)", value: formatter.format(materialCosts.totalCost * 0.12) },
+        { label: "Projected Sale", value: formatter.format(marketValue.saleValue) },
+        { label: "Net Margin", value: formatter.format(marketValue.saleValue - materialCosts.totalCost * 1.35) },
+    ];
+}
+
+function buildSystems(design, energyUse) {
+    const heatPump = design.params.energySystem === "geothermal" ? "Geothermal Heat Pump" : "Inverter Mini-Split";
+    const hvac = `${heatPump} · ${Math.round(energyUse / 120)} SEER`;
+    const electrical = `${design.params.energySystem === "microgrid" ? "Dual-fed microgrid" : "Smart load center"} with ${Math.round(energyUse / 365)}kWh storage`;
+    const water = {
+        rainwater: "Rainwater cistern + UV purification",
+        municipal: "High-efficiency municipal hookup",
+        offgrid: "Atmospheric water generator",
+    }[design.params.waterStrategy];
+    return [
+        { label: "HVAC", value: hvac },
+        { label: "Electrical", value: electrical },
+        { label: "Water", value: water },
+        { label: "Automation", value: "AI habitat assistant + adaptive shading" },
+    ];
+}
+
+function buildEnvelope(design, climate) {
+    const rValue = { standard: 28, hempcrete: 32, recycled: 30, "mass-timber": 26 }[design.params.envelope];
+    const vapor = climate && climate.humidity > 70 ? "Smart vapor control" : "Breathable membrane";
+    const acoustic = design.params.palette === "industrial" ? "Reverberant acoustic panels" : "Acoustic felt baffles";
+    return [
+        { label: "R-Value", value: `R-${rValue}` },
+        { label: "Air Tightness", value: `${(1.5 * (design.features.glazingRatio + 0.6)).toFixed(1)} ACH50` },
+        { label: "Vapor Strategy", value: vapor },
+        { label: "Acoustic", value: acoustic },
+    ];
+}
+
+function estimateMarketValue(areaSqft, location) {
+    const costIndexByCountry = {
+        us: 1.28,
+        ca: 1.12,
+        gb: 1.45,
+        au: 1.25,
+        de: 1.32,
+        fr: 1.3,
+        jp: 1.38,
+        sg: 1.65,
+    };
+    const defaultCost = 1.1;
+    const basePrice = 240;
+    const countryCode = location?.country_code?.toLowerCase();
+    const costFactor = costIndexByCountry[countryCode] || defaultCost;
+    const saleValue = areaSqft * basePrice * costFactor;
+    const marketPressure = location?.population > 1500000 ? "High Demand" : location?.population > 400000 ? "Emerging" : "Niche";
+    return { saleValue, marketPressure, costFactor };
+}
+
+function assessClimate(climate, location) {
+    if (!climate) {
+        return [
+            { type: "Data Pending", level: "Medium", description: "Run a generation to synchronize site-specific climate analytics." },
+        ];
+    }
+    const risks = [];
+    const floodIndex = climate.precipitation > 1400 || climate.seaLevel === "coastal" ? "High" : climate.precipitation > 900 ? "Medium" : "Low";
+    const heatIndex = climate.temperature > 28 ? "High" : climate.temperature > 22 ? "Medium" : "Low";
+    const windIndex = climate.wind > 12 ? "High" : climate.wind > 8 ? "Medium" : "Low";
+    const fireIndex = climate.humidity < 40 && climate.precipitation < 600 ? "High" : climate.humidity < 55 ? "Medium" : "Low";
+    risks.push({ type: "Flooding & Storm Surge", level: floodIndex, description: `Annual rainfall ${climate.precipitation}mm with prevailing ${climate.wind.toFixed(1)}m/s winds.` });
+    risks.push({ type: "Extreme Heat", level: heatIndex, description: `Average temperature ${climate.temperature.toFixed(1)}°C and ${climate.degreeDays} heating degree days.` });
+    risks.push({ type: "High Winds", level: windIndex, description: `Gust potential ${climate.wind.toFixed(1)}m/s; design roof uplift anchors accordingly.` });
+    risks.push({ type: "Wildfire", level: fireIndex, description: `Relative humidity ${climate.humidity}% with vegetation index ${climate.vegetation}.` });
+    return risks;
+}
+
+function buildClimateStrategies(risks, design) {
+    const strategies = [];
+    if (!risks) return strategies;
+    const highRisk = risks.filter((r) => r.level === "High");
+    const mediumRisk = risks.filter((r) => r.level === "Medium");
+    strategies.push({ label: "Structure", value: `${design.params.envelope} shell + hurricane straps` });
+    strategies.push({ label: "Drainage", value: highRisk.some((r) => r.type.includes("Flood")) ? "Elevated plinth + perimeter swales" : "Permeable landscape" });
+    strategies.push({ label: "Cooling", value: mediumRisk.some((r) => r.type.includes("Heat")) ? "Phase-change insulation + radiant cooling" : "Passive cross ventilation" });
+    strategies.push({ label: "Fire Resistance", value: highRisk.some((r) => r.type.includes("Wildfire")) ? "Intumescent coatings + ember screens" : "Fire-resistant landscaping" });
+    strategies.push({ label: "Energy Backup", value: highRisk.some((r) => r.type.includes("High Winds")) ? "Storm-mode battery reserve" : "Standard resilience kit" });
+    return strategies;
+}
+
+async function geocodeLocation(query) {
+    if (!query) return null;
+    try {
+        const res = await fetch(`https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(query)}&count=1`);
+        if (!res.ok) throw new Error("Geocoding failed");
+        const data = await res.json();
+        return data.results?.[0] || null;
+    } catch (error) {
+        console.warn("Geocoding error", error);
+        return null;
+    }
+}
+
+async function fetchClimate(lat, lon) {
+    if (typeof lat !== "number" || typeof lon !== "number") return null;
+    try {
+        const res = await fetch(`https://climate-api.open-meteo.com/v1/climate?latitude=${lat}&longitude=${lon}&start_year=2000&end_year=2020&models=CMIP6&daily=temperature_2m_max,precipitation_sum,wind_speed_10m_mean,relative_humidity_2m_mean`);
+        if (!res.ok) throw new Error("Climate query failed");
+        const data = await res.json();
+        const temperature = average(data?.daily?.temperature_2m_max?.map((v) => v?.value));
+        const precipitation = average(data?.daily?.precipitation_sum?.map((v) => v?.value)) * 365;
+        const wind = average(data?.daily?.wind_speed_10m_mean?.map((v) => v?.value));
+        const humidity = average(data?.daily?.relative_humidity_2m_mean?.map((v) => v?.value));
+        const vegetation = precipitation > 1200 ? "lush" : precipitation > 600 ? "moderate" : "arid";
+        const degreeDays = Math.max(2500, Math.min(6200, Math.round(4000 + (18 - temperature) * 120)));
+        return { temperature, precipitation: Math.round(precipitation), wind, humidity: Math.round(humidity), vegetation, degreeDays };
+    } catch (error) {
+        console.warn("Climate error", error);
+        return null;
+    }
+}
+
+function average(arr) {
+    if (!Array.isArray(arr) || arr.length === 0) return 0;
+    return arr.reduce((sum, v) => sum + v, 0) / arr.length;
+}
+
+function environmentFromLocation(location, manual) {
+    if (manual && manual !== "auto") return manual;
+    if (!location) return "forest";
+    const coastalCountries = ["us", "ca", "au", "es", "pt", "it", "jp", "gb", "br"];
+    if (coastalCountries.includes(location.country_code?.toLowerCase()) && location.longitude && Math.abs(location.longitude) < 50) return "coastal";
+    if (location.population > 1000000) return "urban";
+    if (location.latitude > 55 || location.latitude < -55) return "forest";
+    return location.elevation > 800 ? "mountain" : "forest";
+}
+
+function updateEnvironment(env) {
+    while (environmentGroup.children.length) environmentGroup.remove(environmentGroup.children[0]);
+    const palette = {
+        urban: 0x111827,
+        coastal: 0x0ea5e9,
+        forest: 0x14532d,
+        desert: 0xca8a04,
+        mountain: 0x6b7280,
+    };
+    const color = palette[env] || 0x14532d;
+    ground.material.color.setHex(color);
+
+    if (env === "urban") {
+        const skyline = new THREE.Group();
+        for (let i = 0; i < 8; i++) {
+            const tower = new THREE.Mesh(new THREE.BoxGeometry(1, Math.random() * 6 + 3, 1), new THREE.MeshStandardMaterial({ color: 0x1f2937, metalness: 0.4, roughness: 0.5 }));
+            tower.position.set(-10 + Math.random() * 6, tower.geometry.parameters.height / 2, -8 - Math.random() * 6);
+            skyline.add(tower);
+        }
+        environmentGroup.add(skyline);
+    } else if (env === "coastal") {
+        const water = new THREE.Mesh(new THREE.PlaneGeometry(40, 20), new THREE.MeshStandardMaterial({ color: 0x0ea5e9, transparent: true, opacity: 0.65 }));
+        water.rotation.x = -Math.PI / 2;
+        water.position.set(0, -0.01, -12);
+        environmentGroup.add(water);
+    } else if (env === "forest") {
+        const forest = new THREE.Group();
+        for (let i = 0; i < 25; i++) {
+            const trunk = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.15, 1.8), new THREE.MeshStandardMaterial({ color: 0x92400e }));
+            const canopy = new THREE.Mesh(new THREE.ConeGeometry(0.9, 1.8, 12), new THREE.MeshStandardMaterial({ color: 0x14532d }));
+            trunk.position.set((Math.random() - 0.5) * 18, 0.9, -10 - Math.random() * 10);
+            canopy.position.set(trunk.position.x, 1.8, trunk.position.z);
+            forest.add(trunk, canopy);
+        }
+        environmentGroup.add(forest);
+    } else if (env === "desert") {
+        const dunes = new THREE.Mesh(new THREE.PlaneGeometry(40, 30, 32, 32), new THREE.MeshStandardMaterial({ color: 0xfacc15, side: THREE.DoubleSide }));
+        dunes.rotation.x = -Math.PI / 2;
+        dunes.position.z = -14;
+        environmentGroup.add(dunes);
+    } else if (env === "mountain") {
+        const peak = new THREE.Mesh(new THREE.ConeGeometry(6, 8, 32), new THREE.MeshStandardMaterial({ color: 0x6b7280 }));
+        peak.position.set(-8, 4, -15);
+        environmentGroup.add(peak);
+    }
+}
+
+async function generateDesigns() {
+    ui.generate.disabled = true;
+    ui.generate.textContent = "⏳ Synthesizing";
+    state.designs = [];
+    ui.designList.innerHTML = "";
+
+    const params = {
+        location: document.getElementById("location").value,
+        lotWidth: Number(document.getElementById("lotWidth").value),
+        lotLength: Number(document.getElementById("lotLength").value),
+        orientation: document.getElementById("orientation").value,
+        environment: document.getElementById("environment").value,
+        area: Number(document.getElementById("area").value) / 10.7639,
+        floors: Number(document.getElementById("floors").value),
+        bedrooms: Number(document.getElementById("bedrooms").value),
+        bathrooms: Number(document.getElementById("bathrooms").value),
+        sustainability: document.getElementById("sustainability").value,
+        envelope: document.getElementById("envelope").value,
+        variantCount: Number(document.getElementById("variantCount").value),
+        energySystem: document.getElementById("energySystem").value,
+        waterStrategy: document.getElementById("waterStrategy").value,
+        fabricator: document.getElementById("fabricator").value,
+        palette: document.getElementById("palette").value,
+        budget: Number(document.getElementById("budget").value),
+    };
+
+    const location = await geocodeLocation(params.location);
+    const climate = location ? await fetchClimate(location.latitude, location.longitude) : null;
+    if (climate) climate.seaLevel = params.environment === "coastal" ? "coastal" : undefined;
+    const environment = environmentFromLocation(location, params.environment);
+    updateEnvironment(environment);
+
+    for (let i = 0; i < params.variantCount; i++) {
+        const seed = crypto.getRandomValues(new Uint32Array(1))[0];
+        const design = generateLayout(seed, params);
+        state.designs.push({ design, seed, analytics: computeAnalytics(design, { climate, location }) });
+    }
+
+    ui.designList.innerHTML = state.designs
+        .map(
+            (entry, idx) => `
+            <div class="design-item" data-index="${idx}">
+                <strong>${entry.design.id}</strong>
+                <span>${entry.analytics.programProfile}</span>
+                <span>${Math.round(entry.analytics.areaSqft).toLocaleString()} sqft · ${entry.design.features.roofType}</span>
+            </div>
+        `
+        )
+        .join("");
+
+    ui.designList.querySelectorAll(".design-item").forEach((item) => {
+        item.addEventListener("click", () => activateDesign(Number(item.dataset.index)));
+    });
+
+    activateDesign(0);
+    ui.generate.disabled = false;
+    ui.generate.textContent = "⚙️ Generate Intelligent Layouts";
+}
+
+function activateDesign(index) {
+    ui.designList.querySelectorAll(".design-item").forEach((item) => item.classList.remove("active"));
+    const item = ui.designList.querySelector(`[data-index="${index}"]`);
+    if (item) item.classList.add("active");
+    const selected = state.designs[index];
+    if (!selected) return;
+    state.activeDesign = selected;
+    buildDesign(selected.design);
+    describeDesign(selected.design, selected.analytics);
+    ui.simulationStatus.textContent = `Ready to simulate ${selected.design.id}.`;
+}
+
+ui.generate.addEventListener("click", generateDesigns);
+
+window.addEventListener("resize", () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+});
+
+function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+    renderer.render(scene, camera);
+}
+animate();
+
+function playSimulation(record = false) {
+    if (!state.activeDesign) return;
+    if (state.animation) cancelAnimationFrame(state.animation);
+    const totalDuration = 4500;
+    const start = performance.now();
+    const roof = lensGroups.roof.children[0];
+    const initialRoofY = roof ? roof.position.y : 0;
+    const walls = lensGroups.walls.children.filter((child) => !child.userData?.isSlab);
+
+    const animateStep = (time) => {
+        const elapsed = Math.min(time - start, totalDuration);
+        const progress = elapsed / totalDuration;
+        walls.forEach((wall) => {
+            const baseScale = wall.userData.originalScaleY ?? 1;
+            const eased = Math.max(0.01, progress);
+            wall.scale.y = baseScale * eased;
+            wall.position.y = (wall.userData.room?.height || 3) * eased / 2;
+        });
+        if (roof) {
+            roof.position.y = initialRoofY + Math.sin(progress * Math.PI) * 0.35;
+        }
+        if (elapsed < totalDuration) {
+            state.animation = requestAnimationFrame(animateStep);
+        } else {
+            ui.simulationStatus.textContent = `Simulation complete for ${state.activeDesign.design.id}.`;
+            if (record && state.mediaRecorder) state.mediaRecorder.stop();
+        }
+    };
+    walls.forEach((wall) => {
+        const baseScale = wall.userData.originalScaleY ?? 1;
+        wall.scale.y = Math.max(0.01, baseScale * 0.01);
+        wall.position.y = (wall.userData.room?.height || 3) * 0.01;
+    });
+    ui.simulationStatus.textContent = record ? "Recording simulation…" : "Simulating 3D printing sequence…";
+    state.animation = requestAnimationFrame(animateStep);
+}
+
+ui.simulatePrint.addEventListener("click", () => playSimulation(false));
+
+ui.recordVideo.addEventListener("click", async () => {
+    if (!state.activeDesign) return;
+    if (state.mediaRecorder) {
+        state.mediaRecorder.stop();
+        state.mediaRecorder = null;
+    }
+    const stream = renderer.domElement.captureStream(60);
+    const options = { mimeType: "video/webm;codecs=vp9" };
+    const mediaRecorder = new MediaRecorder(stream, options);
+    state.recordedChunks = [];
+    mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) state.recordedChunks.push(event.data);
+    };
+    mediaRecorder.onstop = () => {
+        const blob = new Blob(state.recordedChunks, { type: "video/webm" });
+        const url = URL.createObjectURL(blob);
+        ui.simulationVideo.src = url;
+        ui.downloadLink.href = url;
+        ui.videoPreview.hidden = false;
+        ui.simulationStatus.textContent = "Simulation video ready.";
+    };
+    state.mediaRecorder = mediaRecorder;
+    mediaRecorder.start();
+    playSimulation(true);
+});
+
+applyLensVisibility();
+ui.simulationStatus.textContent = "Awaiting design synthesis.";

--- a/styles/tiny-house.css
+++ b/styles/tiny-house.css
@@ -1,0 +1,523 @@
+:root {
+    color-scheme: dark;
+    --bg: #0f172a;
+    --panel: #111827ee;
+    --accent: #38bdf8;
+    --accent-2: #f97316;
+    --text: #f8fafc;
+    --muted: #94a3b8;
+    font-size: 16px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Inter", system-ui, sans-serif;
+    background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.15), transparent 45%),
+        radial-gradient(circle at 80% 0%, rgba(244, 114, 182, 0.08), transparent 40%),
+        var(--bg);
+    color: var(--text);
+    display: flex;
+    height: 100vh;
+    overflow: hidden;
+}
+
+h1,
+h2,
+h3,
+h4 {
+    margin: 0;
+}
+
+button,
+select,
+input,
+textarea {
+    font-family: inherit;
+}
+
+.sidebar {
+    width: 410px;
+    background: var(--panel);
+    backdrop-filter: blur(16px);
+    padding: 1.5rem;
+    overflow-y: auto;
+    border-right: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.sidebar h1 {
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+}
+
+.sidebar p.description {
+    font-size: 0.9rem;
+    color: var(--muted);
+    margin-bottom: 1.2rem;
+    line-height: 1.4;
+}
+
+.control-group {
+    margin-bottom: 1.2rem;
+    padding: 1rem;
+    border-radius: 0.75rem;
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.control-group header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+}
+
+.control-group header h2 {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.control-group header span {
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.control-group header::after {
+    content: "▼";
+    font-size: 0.75rem;
+    color: var(--muted);
+    transition: transform 0.2s ease;
+}
+
+.control-group.collapsed header::after {
+    transform: rotate(-90deg);
+}
+
+.control-group.collapsed .group-content {
+    display: none;
+}
+
+.group-content {
+    margin-top: 0.8rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+label {
+    font-size: 0.85rem;
+    color: var(--muted);
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+input[type="number"],
+input[type="text"],
+select,
+textarea {
+    padding: 0.55rem 0.7rem;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(15, 23, 42, 0.8);
+    color: var(--text);
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    border-color: var(--accent);
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+}
+
+.dual-input {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.7rem;
+}
+
+.slider-input {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.slider-input input[type="range"] {
+    flex: 1;
+}
+
+.primary-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: none;
+    border-radius: 999px;
+    padding: 0.8rem 1.3rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    background: linear-gradient(135deg, var(--accent), var(--accent-2));
+    color: #0f172a;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.primary-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 30px -16px var(--accent-2);
+}
+
+.primary-button:active {
+    transform: translateY(1px);
+}
+
+.design-list {
+    margin-top: 1rem;
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    border-radius: 0.75rem;
+    overflow: hidden;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.design-item {
+    padding: 0.7rem 0.9rem;
+    background: rgba(15, 23, 42, 0.72);
+    cursor: pointer;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+    display: grid;
+    gap: 0.25rem;
+}
+
+.design-item:hover,
+.design-item.active {
+    background: rgba(56, 189, 248, 0.08);
+}
+
+.design-item span {
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+.viewport {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: #020617;
+}
+
+.viewport-header {
+    padding: 1rem 1.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.viewport-header h2 {
+    font-size: 1.2rem;
+    font-weight: 600;
+}
+
+.viewport-tabs {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.viewport-tabs button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.5rem 0.9rem;
+    font-size: 0.85rem;
+    background: rgba(15, 23, 42, 0.8);
+    color: var(--muted);
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.viewport-tabs button.active {
+    background: rgba(56, 189, 248, 0.12);
+    color: var(--text);
+}
+
+#render-wrapper {
+    position: relative;
+    flex: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 2.3fr) minmax(300px, 1fr);
+    overflow: hidden;
+}
+
+#render-container {
+    position: relative;
+}
+
+#three-canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.overlays {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.lens-toggle {
+    padding: 0.4rem 0.7rem;
+    border-radius: 0.6rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(2, 6, 23, 0.8);
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+}
+
+.lens-toggle input {
+    accent-color: var(--accent);
+}
+
+.info-panel {
+    padding: 1.2rem;
+    overflow-y: auto;
+    border-left: 1px solid rgba(148, 163, 184, 0.12);
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.85));
+    display: none;
+}
+
+.info-panel.active {
+    display: block;
+}
+
+.info-panel h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 0.8rem;
+}
+
+.info-section {
+    margin-bottom: 1.1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.info-section:last-child {
+    border-bottom: none;
+}
+
+.info-section h4 {
+    font-size: 0.95rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.info-grid {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.info-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+}
+
+.pill {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 0.25rem 0.65rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    background: rgba(56, 189, 248, 0.16);
+    color: var(--accent);
+}
+
+.pill-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+
+.pill-group span {
+    background: rgba(148, 163, 184, 0.15);
+    color: var(--muted);
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+.badge::before {
+    content: "";
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: currentColor;
+}
+
+.hero-metric {
+    display: grid;
+    gap: 0.25rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: 0.75rem;
+    background: rgba(56, 189, 248, 0.08);
+    border: 1px solid rgba(56, 189, 248, 0.15);
+}
+
+.hero-metric h4 {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+}
+
+.hero-metric span {
+    font-size: 1.4rem;
+    font-weight: 600;
+}
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 0.9rem;
+}
+
+.video-preview {
+    display: grid;
+    gap: 0.5rem;
+    background: rgba(15, 23, 42, 0.7);
+    border-radius: 0.75rem;
+    padding: 0.8rem;
+    border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.video-preview video {
+    width: 100%;
+    border-radius: 0.5rem;
+    background: #000;
+    min-height: 150px;
+}
+
+.simulation-controls {
+    margin-top: 1rem;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.secondary-button {
+    padding: 0.6rem 0.9rem;
+    border-radius: 0.6rem;
+    background: rgba(56, 189, 248, 0.12);
+    border: 1px solid rgba(56, 189, 248, 0.35);
+    color: var(--accent);
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+
+.secondary-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.status-bar {
+    font-size: 0.78rem;
+    color: var(--muted);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.82rem;
+}
+
+th,
+td {
+    text-align: left;
+    padding: 0.45rem 0.35rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+th {
+    color: var(--muted);
+    font-weight: 500;
+}
+
+.climate-risk {
+    display: grid;
+    gap: 0.6rem;
+}
+
+.risk-card {
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    display: grid;
+    gap: 0.35rem;
+}
+
+.risk-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.85rem;
+}
+
+.risk-card p {
+    margin: 0;
+    font-size: 0.78rem;
+    color: var(--muted);
+    line-height: 1.4;
+}
+
+.risk-high {
+    color: #f97316;
+}
+
+.risk-medium {
+    color: #fbbf24;
+}
+
+.risk-low {
+    color: #4ade80;
+}
+
+@media (max-width: 1400px) {
+    body {
+        flex-direction: column;
+    }
+
+    .sidebar {
+        width: 100%;
+        height: 45vh;
+        border-right: none;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+    }
+
+    #render-wrapper {
+        grid-template-columns: 1fr;
+    }
+
+    .info-panel {
+        border-left: none;
+        border-top: 1px solid rgba(148, 163, 184, 0.12);
+    }
+}

--- a/tiny-house-studio.html
+++ b/tiny-house-studio.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Parametric Tiny House Fabricator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="styles/tiny-house.css" />
+</head>
+<body>
+    <aside class="sidebar">
+        <h1>Parametric Tiny House Fabricator</h1>
+        <p class="description">
+            Auto-generate thousands of bespoke micro-homes optimized for cost, sustainability, energy performance, and climate resilience.
+            Tune constraints, analyze build intelligence, and export fabrication-ready data alongside immersive visualization.
+        </p>
+
+        <div class="control-group" data-collapsible>
+            <header>
+                <h2>Site & Orientation</h2>
+                <span>Contextual Intelligence</span>
+            </header>
+            <div class="group-content">
+                <label>
+                    Project Location
+                    <input type="text" id="location" placeholder="e.g. Seattle, WA" />
+                </label>
+                <label>
+                    Lot Dimensions (ft)
+                    <div class="dual-input">
+                        <input type="number" id="lotWidth" min="20" value="60" />
+                        <input type="number" id="lotLength" min="20" value="100" />
+                    </div>
+                </label>
+                <label>
+                    Solar Orientation Preference
+                    <select id="orientation">
+                        <option value="balanced">Balanced</option>
+                        <option value="southern">Max Southern Exposure</option>
+                        <option value="eastern">Morning Light</option>
+                        <option value="western">Sunset Views</option>
+                    </select>
+                </label>
+                <label>
+                    Environmental Setting
+                    <select id="environment">
+                        <option value="auto">Auto-detect</option>
+                        <option value="urban">Urban</option>
+                        <option value="coastal">Coastal</option>
+                        <option value="forest">Forest</option>
+                        <option value="desert">Desert</option>
+                    </select>
+                </label>
+            </div>
+        </div>
+
+        <div class="control-group" data-collapsible>
+            <header>
+                <h2>Program & Performance</h2>
+                <span>Spatial DNA</span>
+            </header>
+            <div class="group-content">
+                <label>
+                    Living Area Target (sqft)
+                    <input type="number" id="area" min="200" value="420" />
+                </label>
+                <label>
+                    Floors
+                    <select id="floors">
+                        <option value="1">Single Level</option>
+                        <option value="2">Two Story</option>
+                    </select>
+                </label>
+                <label>
+                    Rooms
+                    <div class="dual-input">
+                        <input type="number" id="bedrooms" min="1" value="2" />
+                        <input type="number" id="bathrooms" min="1" value="1" />
+                    </div>
+                </label>
+                <label>
+                    Sustainability Priority
+                    <select id="sustainability">
+                        <option value="balanced">Balanced Performance</option>
+                        <option value="carbon">Ultra Low-Carbon</option>
+                        <option value="energy">Net-Positive Energy</option>
+                        <option value="luxury">Luxury Finishes</option>
+                    </select>
+                </label>
+                <label>
+                    Envelope Strategy
+                    <select id="envelope">
+                        <option value="standard">Standard SIP Panels</option>
+                        <option value="hempcrete">Hempcrete Hybrid</option>
+                        <option value="recycled">Recycled Polymer Shell</option>
+                        <option value="mass-timber">Mass Timber Ribs</option>
+                    </select>
+                </label>
+                <div class="slider-input">
+                    <label style="flex: 1 1 auto;">
+                        Design Variants
+                        <span class="badge" id="variantCountLabel">12 layouts queued</span>
+                    </label>
+                    <input type="range" id="variantCount" min="3" max="24" step="3" value="12" />
+                </div>
+            </div>
+        </div>
+
+        <div class="control-group" data-collapsible>
+            <header>
+                <h2>Systems & Fabrication</h2>
+                <span>Build Logistics</span>
+            </header>
+            <div class="group-content">
+                <label>
+                    Energy System
+                    <select id="energySystem">
+                        <option value="hybrid">Solar + Battery Hybrid</option>
+                        <option value="geothermal">Geothermal Loop</option>
+                        <option value="grid">High-Efficiency Grid Tie</option>
+                        <option value="microgrid">Microgrid Ready</option>
+                    </select>
+                </label>
+                <label>
+                    Water Strategy
+                    <select id="waterStrategy">
+                        <option value="rainwater">Rainwater Harvesting + Greywater</option>
+                        <option value="municipal">Municipal Connection</option>
+                        <option value="offgrid">Off-Grid Atmospheric</option>
+                    </select>
+                </label>
+                <label>
+                    Printing Fabricator
+                    <select id="fabricator">
+                        <option value="gantry">Gantry Polymer-Concrete</option>
+                        <option value="arm">Robotic Arm Extrusion</option>
+                        <option value="swarm">Swarm Micro-Extruders</option>
+                    </select>
+                </label>
+                <label>
+                    Finish Palette
+                    <select id="palette">
+                        <option value="minimal">Minimal Nordic</option>
+                        <option value="industrial">Industrial Loft</option>
+                        <option value="organic">Organic Earth</option>
+                        <option value="futuristic">Futuristic Metallic</option>
+                    </select>
+                </label>
+                <label>
+                    Budget Ceiling (USD)
+                    <input type="number" id="budget" min="50000" value="165000" />
+                </label>
+            </div>
+        </div>
+
+        <button class="primary-button" id="generate">⚙️ Generate Intelligent Layouts</button>
+
+        <div class="design-list" id="designList"></div>
+    </aside>
+
+    <main class="viewport">
+        <div class="viewport-header">
+            <h2 id="activeDesignTitle">Awaiting Generation</h2>
+            <div class="viewport-tabs">
+                <button data-tab="overview" class="active">Overview</button>
+                <button data-tab="materials">Materials & Cost</button>
+                <button data-tab="systems">Systems</button>
+                <button data-tab="climate">Climate Risk</button>
+            </div>
+        </div>
+        <div id="render-wrapper">
+            <section id="render-container">
+                <canvas id="three-canvas"></canvas>
+                <div class="overlays">
+                    <label class="lens-toggle"><input type="checkbox" id="toggleRoof" checked /> Show Roof</label>
+                    <label class="lens-toggle"><input type="checkbox" id="toggleWalls" checked /> Solid Walls</label>
+                    <label class="lens-toggle"><input type="checkbox" id="toggleStructure" checked /> Structural Frame</label>
+                    <label class="lens-toggle"><input type="checkbox" id="toggleSystems" checked /> MEP Systems</label>
+                </div>
+            </section>
+            <section class="info-panel active" data-tab-panel="overview">
+                <h3>Design Synopsis</h3>
+                <div class="metrics-grid">
+                    <div class="hero-metric">
+                        <h4>Gross Area</h4>
+                        <span id="metricArea">0 sqft</span>
+                    </div>
+                    <div class="hero-metric">
+                        <h4>Embodied Carbon</h4>
+                        <span id="metricCarbon">— kg CO₂e</span>
+                    </div>
+                    <div class="hero-metric">
+                        <h4>Energy Intensity</h4>
+                        <span id="metricEnergy">— kWh/yr</span>
+                    </div>
+                </div>
+                <div class="info-section">
+                    <h4>Spatial Composition</h4>
+                    <div class="info-grid" id="layoutSummary"></div>
+                </div>
+                <div class="info-section">
+                    <h4>Performance Highlights</h4>
+                    <div class="pill-group" id="highlightPills"></div>
+                </div>
+                <div class="info-section">
+                    <h4>Market Intelligence</h4>
+                    <div class="info-grid" id="marketInsights"></div>
+                </div>
+                <div class="simulation-controls">
+                    <button class="secondary-button" id="simulatePrint">🎥 Play Printing Simulation</button>
+                    <button class="secondary-button" id="recordVideo">⬇️ Export Simulation Video</button>
+                    <div class="status-bar" id="simulationStatus">Simulation idle.</div>
+                    <div class="video-preview" id="videoPreview" hidden>
+                        <strong>Printable Simulation Capture</strong>
+                        <video id="simulationVideo" controls></video>
+                        <a id="downloadLink" class="secondary-button" download="tiny-house-simulation.webm">Download Video</a>
+                    </div>
+                </div>
+            </section>
+            <section class="info-panel" data-tab-panel="materials">
+                <h3>Fabrication Economics</h3>
+                <div class="info-section">
+                    <h4>Bill of Materials</h4>
+                    <table id="materialsTable">
+                        <thead>
+                            <tr>
+                                <th>Material</th>
+                                <th>Quantity</th>
+                                <th>Unit Cost</th>
+                                <th>Total</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+                <div class="info-section">
+                    <h4>Fabrication Timeline</h4>
+                    <div class="info-grid" id="timelineInsights"></div>
+                </div>
+                <div class="info-section">
+                    <h4>Financial Projection</h4>
+                    <div class="info-grid" id="financialInsights"></div>
+                </div>
+            </section>
+            <section class="info-panel" data-tab-panel="systems">
+                <h3>Systems Coordination</h3>
+                <div class="info-section">
+                    <h4>Mechanical | Electrical | Plumbing</h4>
+                    <div class="info-grid" id="systemsInsights"></div>
+                </div>
+                <div class="info-section">
+                    <h4>Envelope & Comfort</h4>
+                    <div class="info-grid" id="envelopeInsights"></div>
+                </div>
+            </section>
+            <section class="info-panel" data-tab-panel="climate">
+                <h3>Climate Resilience & Risk</h3>
+                <div class="info-section">
+                    <h4>Hazard Outlook</h4>
+                    <div class="climate-risk" id="climateRisk"></div>
+                </div>
+                <div class="info-section">
+                    <h4>Adaptive Strategies</h4>
+                    <div class="info-grid" id="climateStrategies"></div>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <script type="module" src="scripts/tiny-house.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- tag the floor slab when building a design so it can be excluded from printing animations
- filter the simulation wall list to skip the slab and leave its transform untouched during playback
- initialize only actual wall meshes for the animation ramp so the floor remains planted on the ground plane

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc0f9b2b088327b6fcfa9c14d273da