### PR TITLE
Add inline favicon to prevent 404 errors

### DIFF
--- a/tiny-house-studio.html
+++ b/tiny-house-studio.html
@@ -7,6 +7,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link
+        rel="icon"
+        type="image/svg+xml"
+        href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%20100%20100%22%3E%0A%3Crect%20width%3D%22100%22%20height%3D%22100%22%20rx%3D%2220%22%20fill%3D%22%231d3557%22/%3E%0A%3Cpath%20d%3D%22M20%2058%20L50%2030%20L80%2058%20V80%20H60%20V62%20H40%20V80%20H20%20Z%22%20fill%3D%22%23f1faee%22/%3E%0A%3C/svg%3E"
+    />
     <link rel="stylesheet" href="styles/tiny-house.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add an inline SVG favicon data URI so browsers stop requesting a missing file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3b400890832797c5db29573f9b63